### PR TITLE
moved variable definitions to be last

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -744,6 +744,7 @@ connection.onNotification('Export namespace', (text: string) => {
 	const namespaceDefinitionsLines: string[] = [];
 	const classDefinitionsLines: string[] = [];
 	const memberDefinitionsLines: string[] = [];
+    const variableDefinitionsLines: string[] = [];
 	const functions: NamespaceFunction[] = [];
 	const methods: ClassMethod[] = [];
 	const constructors: ClassConstructor[] = [];
@@ -812,13 +813,13 @@ connection.onNotification('Export namespace', (text: string) => {
 				});
 			}
 			else if (variableRegExpRes !== null)
-				memberDefinitionsLines.push(`@bypass /variable define ${namespaceName} ${lines[j].trim()}`);
+				variableDefinitionsLines.push(`@bypass /variable define ${namespaceName} ${lines[j].trim()}`);
 			}
 
 		i = namespaceEndLine;
 	}
 	const script: string = namespaceDefinitionsLines.join('\n') + '\n' +
-		classDefinitionsLines.join('\n') + '\n' + memberDefinitionsLines.join('\n');
+		classDefinitionsLines.join('\n') + '\n' + memberDefinitionsLines.join('\n') + '\n' + variableDefinitionsLines.join('\n');
 	const result: NamespaceUploadResult = {
 		defineScript: script,
 		functions: functions, 


### PR DESCRIPTION
originally, namespaced variables were sometimes defined before type constructors and methods. this meant if you had a namespace like:

(1)    type define myNamespace customType
(2)    var define myNamespace customType instance = customType(3)
(3)    type define constructor customType(Int parameter)

then #2 could be run in the namespace file before #3, but this would cause errors (as the constructor for customType doesn't exist.
to fix this, Type constructors and methods, as well as functions, need to be defined before variables are defined - in fact, variables should be the very last thing defined. these proposed changes make it so variables are the last thing defined, by pushing variables to a separate list (before, they existed in memberDefinitionsLines along with constructors and functions, but now are in variableDefinitionsLines alone).