### PR TITLE
player.getVelocity is no longer available

### DIFF
--- a/resources/default.nms
+++ b/resources/default.nms
@@ -144,12 +144,6 @@
 		Float getYaw()
 		# Gets the entity's current rotation around the x axis.
 		Float getPitch()
-		# Gets the entity's current velocity in the x direction.
-		Double getVelocityX()
-		# Gets the entity's current velocity in the y direction.
-		Double getVelocityY()
-		# Gets the entity's current velocity in the z direction.
-		Double getVelocityZ()
 		# Gets the current world this entity resides in.
 		String getWorld()
 		# Returns true if this entity has been marked for removal.

--- a/resources/default.nms
+++ b/resources/default.nms
@@ -389,11 +389,11 @@
 		Double getDirectionX()
 		Double getDirectionY()
 		Double getDirectionZ()
-		# Gets the entity's current velocity in the x direction.
+		# Gets the entity's current acceleration (yes, acceleration) in the x direction.
 		Double getVelocityX()
-		# Gets the entity's current velocity in the y direction.
+		# Gets the entity's current acceleration (yes, acceleration) in the y direction.
 		Double getVelocityY()
-		# Gets the entity's current velocity in the z direction.
+		# Gets the entity's current acceleration (yes, acceleration) in the z direction.
 		Double getVelocityZ()
 		# Gets the current world this entity resides in.
 		String getWorld()


### PR DESCRIPTION
Was trying to use player.getVelocityX(), Y and Z and they are no longer available apparently due to "jankyness"

Entity.getVelocityX(), Y and Z returns the acceleration of the entity and not the velocity