### PR TITLE
Function Import Fix

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -47,7 +47,7 @@ interface IncludedFileInfo {
 interface NamespaceFunction {
 	namespaceName: string,
 	functionName: string,
-	functionWithSignature: string
+	functionSignature: string
 }
 
 interface ClassConstructor {
@@ -60,7 +60,7 @@ interface ClassMethod {
 	namespaceName: string,
 	className: string,
 	methodName: string,
-	methodWithSignature: string
+	methodSignature: string
 }
 
 interface NamespaceUploadResult {
@@ -676,7 +676,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${functionInfo.functionName}.msc`, cache,
 							functionLink => {
-								importLines.push(`@bypass /script import function ${functionInfo.namespaceName} ${functionInfo.functionWithSignature} ${functionLink}`);
+								importLines.push(`@bypass /script import function ${functionInfo.namespaceName} ${functionInfo.functionSignature} ${functionLink}`);
 							}, incrementProgress
 						);
 					}
@@ -696,7 +696,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${methodInfo.className}/${methodInfo.methodName}.msc`, cache,
 							methodLink => {
-								importLines.push(`@bypass /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodWithSignature} ${methodLink}`);
+								importLines.push(`@bypass /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodSignature} ${methodLink}`);
 							}, incrementProgress
 						);
 					}
@@ -707,10 +707,10 @@ export function activate(context: ExtensionContext) {
 						initLink => {
 							namespaceInfo.defineScript += '\n' + `# Namespace initialisation function from ${namespaceInfo.name}/__init__.msc` +
 								'\n' + `@bypass /function define ${namespaceInfo.name} wilexafixu()`;
-							importLines.push(`@bypass /script import function ${namespaceInfo.name} wilexafixu ${initLink}`);
+							importLines.push(`@bypass /script import function ${namespaceInfo.name} wilexafixu() ${initLink}`);
 							namespaceInfo.initializeScript += '\n\n' + '@player &7[&#20a0d0VSCode&7] &eExecuting namespace initialisation function.' +
 								'\n' + `@bypass /function execute ${namespaceInfo.name}::wilexafixu()` +
-								'\n' + `@bypass /function remove ${namespaceInfo.name} wilexafixu`;
+								'\n' + `@bypass /function remove ${namespaceInfo.name} wilexafixu()`;
 						}, incrementProgress, true
 					);
 
@@ -755,7 +755,7 @@ export function activate(context: ExtensionContext) {
 			if (finalScript === null) return;
 
 			// removes the script from the block it was on, and notifies the player in chat
-			finalScript += '@bypass /script remove interact {{block.getX()}} {{block.getY()}} {{block.getZ()}}';
+			finalScript += '@bypass /script remove interact {{block.getX()}} {{block.getY()}} {{block.getZ()}} {{block.getWorld()}}';
 			finalScript += '\n' + '@player &7[&#20a0d0VSCode&7] &aNamespace import finished!';
 
 			// uploads this script

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -59,7 +59,8 @@ interface ClassConstructor {
 interface ClassMethod {
 	namespaceName: string,
 	className: string,
-	methodName: string
+	methodName: string,
+	methodWithSignature: string
 }
 
 interface NamespaceUploadResult {
@@ -695,7 +696,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${methodInfo.className}/${methodInfo.methodName}.msc`, cache,
 							methodLink => {
-								importLines.push(`@bypass /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodName} ${methodLink}`);
+								importLines.push(`@bypass /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodWithSignature} ${methodLink}`);
 							}, incrementProgress
 						);
 					}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -46,7 +46,8 @@ interface IncludedFileInfo {
 
 interface NamespaceFunction {
 	namespaceName: string,
-	functionName: string
+	functionName: string,
+	functionWithSignature: string
 }
 
 interface ClassConstructor {
@@ -674,7 +675,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${functionInfo.functionName}.msc`, cache,
 							functionLink => {
-								importLines.push(`@bypass /script import function ${functionInfo.namespaceName} ${functionInfo.functionName} ${functionLink}`);
+								importLines.push(`@bypass /script import function ${functionInfo.namespaceName} ${functionInfo.functionWithSignature} ${functionLink}`);
 							}, incrementProgress
 						);
 					}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -771,7 +771,8 @@ interface ClassConstructor {
 interface ClassMethod {
 	namespaceName: string,
 	className: string,
-	methodName: string
+	methodName: string,
+	methodWithSignature: string
 }
 interface NamespaceUploadResult {
 	name: string,
@@ -850,7 +851,8 @@ connection.onNotification('Export namespace', (fileInfo: UploadFileInfo) => {
 						methods.push({
 							namespaceName: namespaceName,
 							className: className,
-							methodName: functionRegExpRes[2]
+							methodName: functionRegExpRes[2],
+							methodWithSignature: lines[k].trim()
 						});
 					} else if (constructorRegExpRes !== null) {
 						memberDefinitionsLines.push(`@bypass /type constructor define ${namespaceName} ${lines[k].trim()}`);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -761,7 +761,7 @@ connection.onNotification('processDefaultNamespaces', (text: string) => {
 interface NamespaceFunction {
 	namespaceName: string,
 	functionName: string,
-	functionWithSignature: string
+	functionSignature: string
 }
 interface ClassConstructor {
 	namespaceName: string,
@@ -772,7 +772,7 @@ interface ClassMethod {
 	namespaceName: string,
 	className: string,
 	methodName: string,
-	methodWithSignature: string
+	methodSignature: string
 }
 interface NamespaceUploadResult {
 	name: string,
@@ -852,7 +852,7 @@ connection.onNotification('Export namespace', (fileInfo: UploadFileInfo) => {
 							namespaceName: namespaceName,
 							className: className,
 							methodName: functionRegExpRes[2],
-							methodWithSignature: lines[k].trim()
+							methodSignature: functionRegExpRes[2] + functionRegExpRes[3]
 						});
 					} else if (constructorRegExpRes !== null) {
 						memberDefinitionsLines.push(`@bypass /type constructor define ${namespaceName} ${lines[k].trim()}`);
@@ -889,7 +889,7 @@ connection.onNotification('Export namespace', (fileInfo: UploadFileInfo) => {
 				functions.push({
 					namespaceName: namespaceName,
 					functionName: functionRegExpRes[2],
-					functionWithSignature: lines[j].trim()
+					functionSignature: functionRegExpRes[2] + functionRegExpRes[3]
 				});
 			} else if (variableRegExpRes !== null) {
 				const variableDeclarationEndLine = skipParenthesizedExpressionToEnd(lines, j, namespaceEndLine);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -760,7 +760,8 @@ connection.onNotification('processDefaultNamespaces', (text: string) => {
 
 interface NamespaceFunction {
 	namespaceName: string,
-	functionName: string
+	functionName: string,
+	functionWithSignature: string
 }
 interface ClassConstructor {
 	namespaceName: string,
@@ -885,7 +886,8 @@ connection.onNotification('Export namespace', (fileInfo: UploadFileInfo) => {
 				memberDefinitionsLines.push(`@bypass /function define ${namespaceName} ${lines[j].trim()}`);
 				functions.push({
 					namespaceName: namespaceName,
-					functionName: functionRegExpRes[2]
+					functionName: functionRegExpRes[2],
+					functionWithSignature: lines[j].trim()
 				});
 			} else if (variableRegExpRes !== null) {
 				const variableDeclarationEndLine = skipParenthesizedExpressionToEnd(lines, j, namespaceEndLine);


### PR DESCRIPTION
**NOTE**: this is untested because I can't figure out how to test it (I'm decently confident it's right, though)

Function import syntax changed (same with methods) in the recent commands update:
`/script import function namespace foo https://paste.minr.org/ababababab`
now requires
`/script import function namespace foo(Int arg) https://paste.minr.org/ababababab`
that is, the entire signature rather than just the function name. The same happens with methods, hopefully in order to allow overloading in the future.

This PR changes the code generated upon a namespace upload to account for this. When functions and methods are created, not only is the `functionName` saved, but so is the `functionWithSignature`. This is taken from whatever is put in the line `/function define namespace $HERE` (which is the signature). The same happens for methods.