### PR TITLE
fix: @bypass /script no longer allowed

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msc-client",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"publisher": "Lightwood13",
 	"repository": {
 		"type": "git",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -902,7 +902,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${functionInfo.functionName}.msc`, cache,
 							functionLink => {
-								importLines.push(`@bypass /script import function ${functionInfo.namespaceName} ${functionInfo.functionSignature} ${functionLink}`);
+								importLines.push(`@command /script import function ${functionInfo.namespaceName} ${functionInfo.functionSignature} ${functionLink}`);
 							}, incrementProgress
 						);
 					}
@@ -912,7 +912,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${constructorInfo.className}/${constructorInfo.constructorSignature}.msc`, cache,
 							constructorLink => {
-								importLines.push(`@bypass /script import constructor ${constructorInfo.namespaceName} ${constructorInfo.constructorSignature} ${constructorLink}`);
+								importLines.push(`@command /script import constructor ${constructorInfo.namespaceName} ${constructorInfo.constructorSignature} ${constructorLink}`);
 							}, incrementProgress
 						);
 					}
@@ -922,7 +922,7 @@ export function activate(context: ExtensionContext) {
 						await uploadNamespaceChildFile(
 							namespaceFolderUri, `${methodInfo.className}/${methodInfo.methodName}.msc`, cache,
 							methodLink => {
-								importLines.push(`@bypass /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodSignature} ${methodLink}`);
+								importLines.push(`@command /script import method ${methodInfo.namespaceName} ${methodInfo.className} ${methodInfo.methodSignature} ${methodLink}`);
 							}, incrementProgress
 						);
 					}
@@ -933,7 +933,7 @@ export function activate(context: ExtensionContext) {
 						initLink => {
 							namespaceInfo.defineScript += '\n' + `# Namespace initialisation function from ${namespaceInfo.name}/__init__.msc` +
 								'\n' + `@bypass /function define ${namespaceInfo.name} wilexafixu()`;
-							importLines.push(`@bypass /script import function ${namespaceInfo.name} wilexafixu() ${initLink}`);
+							importLines.push(`@command /script import function ${namespaceInfo.name} wilexafixu() ${initLink}`);
 							namespaceInfo.initializeScript += '\n\n' + '@player &7[&#20a0d0VSCode&7] &eExecuting namespace initialisation function.' +
 								'\n' + `@bypass /function execute ${namespaceInfo.name}::wilexafixu()` +
 								'\n' + `@bypass /function remove ${namespaceInfo.name} wilexafixu()`;
@@ -981,7 +981,7 @@ export function activate(context: ExtensionContext) {
 			if (finalScript === null) return;
 
 			// removes the script from the block it was on, and notifies the player in chat
-			finalScript += '@bypass /script remove interact {{block.getX()}} {{block.getY()}} {{block.getZ()}} {{block.getWorld()}}';
+			finalScript += '@command /script remove interact {{block.getX()}} {{block.getY()}} {{block.getZ()}} {{block.getWorld()}}';
 			finalScript += '\n' + '@player &7[&#20a0d0VSCode&7] &aNamespace import finished!';
 
 			// uploads this script

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "msc",
 	"displayName": "Minr Scripts",
 	"description": "Minr Scripts VS Code extension",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"icon": "images/minr.png",
 	"repository": {
 		"type": "git",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "msc-server",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"engines": {
 		"node": "*"
 	},

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1520,6 +1520,10 @@ function validateScriptOperatorSyntax(trimmedLine: string, firstWord: string, li
 		diagnostics.push(createDiagnostic(lineNumber, lineStartIndex, lineLength, 'Permission changing commands are banned in scripts'));
 	}
 
+	if (trimmedLine.match(/^@bypass \/?script .*/)) {
+		diagnostics.push(createDiagnostic(lineNumber, lineStartIndex, lineLength, '@bypass /script is no longer allowed, use @command /script instead'));
+	}
+
 	if (trimmedLine.match(/^@(bypass|console|command) \/?(chat|gchat|echat|achat|schat|bchat|pchat|tchat|alert|p|t) .*/)) {
 		diagnostics.push(createDiagnostic(lineNumber, lineStartIndex, lineLength, 'Chat commands executed by the player are prohibited in scripts'));
 	}


### PR DESCRIPTION
External update disallows `@bypass /script`; must use `@command /script`.

- Update namespace upload builders in `client/src/extension.ts` to emit `@command /script` for the import and interact-remove lines.
- Add a server diagnostic flagging any `@bypass /script ...` line in .msc files, pointing users to `@command /script`.

Other `@bypass /...` commands are unaffected.